### PR TITLE
bugfix for Controller As

### DIFF
--- a/dist/js/calendar-tpls.js
+++ b/dist/js/calendar-tpls.js
@@ -24,7 +24,7 @@ angular.module('ui.rCalendar', ['ui.rCalendar.tpls'])
             self[key] = angular.isDefined($attrs[key]) ? (index < 5 ? $interpolate($attrs[key])($scope.$parent) : $scope.$parent.$eval($attrs[key])) : calendarConfig[key];
         });
 
-        $scope.$parent.$watch('eventSource', function (value) {
+        $scope.$parent.$watch($attrs['eventSource'], function (value) {
             self.onEventSourceChanged(value);
         });
 


### PR DESCRIPTION
When using controller As syntax, ```$scope.$parent.$watch('eventSource', function(value)...``` passed ```undefined``` as ```value``` causing the Event Source array to be set to undefined, wiping out the calendar. 

Making the change to use ```$attrs['eventSource']``` uses the string literal passed to the config instead of the hardcoded ```'eventSource'```, preserving controller as usage.