### PR TITLE
Incorrect main css path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     ],
     "description": "A pure AngularJS responsive calendar directive",
     "main": [
-        "dist/css/calendar/calendar.css",
+        "dist/css/calendar.css",
         "dist/js/calendar-tpls.js"
     ],
     "keywords": [


### PR DESCRIPTION
Path for the main css file was incorrect causing things like wiredep to not detect it.